### PR TITLE
Better handling for un-modelled residues

### DIFF
--- a/notebooks/pp5_demo.ipynb
+++ b/notebooks/pp5_demo.ipynb
@@ -186,8 +186,8 @@
    ],
    "source": [
     "# Sequence of AAs as a SeqRecord\n",
-    "seq_rec = prec.protein_seq\n",
-    "print(f\"{seq_rec.seq!s}, len={len(seq_rec)}\")"
+    "aa_seq = prec.aa_seq\n",
+    "print(f\"{aa_seq}, len={len(aa_seq)}\")"
    ]
   },
   {

--- a/src/pp5/align.py
+++ b/src/pp5/align.py
@@ -26,7 +26,7 @@ from pp5.external_dbs.pdb import PDB_RCSB
 
 with warnings.catch_warnings():
     warnings.simplefilter("ignore", BiopythonExperimentalWarning)
-    from Bio.Align import substitution_matrices, PairwiseAligner
+    from Bio.Align import substitution_matrices, PairwiseAligner, Alignment
 
 from Bio.AlignIO import MultipleSeqAlignment as MSA
 from Bio.SeqRecord import SeqRecord
@@ -63,7 +63,7 @@ def pairwise_alignment_map(
     tgt_seq: str,
     open_gap_score: float = -10,
     extend_gap_score: float = -0.5,
-) -> Tuple[float, Dict[int, int]]:
+) -> Tuple[Alignment, Dict[int, int]]:
     """
     Aligns between two AA sequences and produces a map from the indices of
     the source sequence to the indices of the target sequence.
@@ -74,7 +74,7 @@ def pairwise_alignment_map(
     :param open_gap_score: Penalty for opening a gap in the alignment.
     :param extend_gap_score: Penalty for extending a gap by one residue.
     :return: A tuple with two elements:
-    -  The alignment score, higher is better.
+    -  The alignment object produced by the aligner.
     -  A dict mapping from an index in the source sequence to the corresponding
        index in the target sequence.
     """
@@ -93,8 +93,6 @@ def pairwise_alignment_map(
 
     multi_alignments = aligner.align(src_seq, tgt_seq)
     alignment = sorted(multi_alignments, key=lambda a: a.score)[-1]
-    score = alignment.score
-    # LOGGER.info(f"{self}: PDB to UNP sequence alignment score={alignment.score}")
 
     # Alignment contains two tuples each of length N (for N matching sub-sequences)
     # (
@@ -117,7 +115,7 @@ def pairwise_alignment_map(
                 continue
             src_to_tgt.append((src_start + j, tgt_start + j))
 
-    return score, dict(src_to_tgt)
+    return alignment, dict(src_to_tgt)
 
 
 def multiseq_align(

--- a/src/pp5/collect.py
+++ b/src/pp5/collect.py
@@ -58,6 +58,7 @@ COL_CG_TEMP = "cg_temp"
 COL_PDB_SOURCE = "pdb_source"
 COL_REJECTED_BY = "rejected_by"
 COL_NUM_ALTLOCS = "num_altlocs"
+COL_NUM_UNMODELLED = "num_unmodelled"
 
 COLLECTION_METADATA_FILENAME = "meta.json"
 ALL_STRUCTS_FILENAME = "meta-structs_all"
@@ -1145,6 +1146,12 @@ def _collect_single_structure(
                 COL_SEQ_LEN: seq_len,
                 COL_SEQ_GAPS: str.join(";", [f"{s}-{e}" for (s, e) in prec.seq_gaps]),
                 COL_NUM_ALTLOCS: prec.num_altlocs,
+                **{
+                    f"{COL_NUM_UNMODELLED}_{suffix}": n
+                    for n, suffix in zip(
+                        prec.num_unmodelled, ["nterm", "inter", "cterm"]
+                    )
+                },
                 COL_PDB_SOURCE: pdb_source,
                 **meta.as_dict(chain_id=chain_id, seq_to_str=True),
             }

--- a/src/pp5/prec.py
+++ b/src/pp5/prec.py
@@ -88,8 +88,8 @@ DEFAULT_BFACTOR_CALC = AtomLocationUncertainty(
     backbone_only=True, unit_cell=None, isotropic=True, scale_as_bfactor=True
 )
 
-# Special insertion code to mark a residue that was missing from the structure.
-ICODE_MISSING_RESIDUE = "M"
+# Special insertion code to mark a residue that is unmodeled the structure.
+ICODE_UNMODELED_RES = "UNMODELED"
 
 
 class ResidueRecord(object):
@@ -904,7 +904,7 @@ class ProteinRecord(object):
                 missing_res_name_single = pdb_meta_aa_seq[curr_meta_seq_idx]
                 missing_res_name = ACIDS_1TO3[missing_res_name_single]
                 curr_residue = Residue(
-                    (" ", curr_meta_seq_idx, ICODE_MISSING_RESIDUE), missing_res_name, 0
+                    (" ", curr_meta_seq_idx, ICODE_UNMODELED_RES), missing_res_name, 0
                 )
                 missing_residues.append(curr_residue)
 

--- a/src/pp5/prec.py
+++ b/src/pp5/prec.py
@@ -1055,7 +1055,7 @@ class ProteinRecord(object):
             )
             residue_recs.append(rr)
 
-        self._protein_seq = all_aa_seq
+        self._aa_seq = all_aa_seq
         self._residue_recs: Dict[str, ResidueRecord] = {
             rr.res_id: rr for rr in residue_recs
         }
@@ -1103,15 +1103,15 @@ class ProteinRecord(object):
         return SeqRecord(Seq(self._dna_seq), self.ena_id, "", "")
 
     @property
-    def protein_seq(self) -> SeqRecord:
+    def aa_seq(self) -> str:
         """
-        :return: Protein sequence as 1-letter AA names. Based on the
-        residues found in the associated PDB structure.
-        Note that the sequence might contain the letter 'X' denoting an
-        unknown AA. This happens if the PDB entry contains non-standard AAs
-        and we chose to ignore such AAs.
+        :return: Protein sequence as 1-letter AA names.
+        Based on the residues found in the associated PDB structure, including those
+        which are not modelled.
+        Note that the sequence might contain the letter 'X' denoting a non-standard
+        AA or a ligand.
         """
-        return SeqRecord(Seq(self._protein_seq), self.pdb_id, "", "")
+        return self._aa_seq
 
     @property
     def seq_gaps(self) -> Sequence[Tuple[str, str]]:

--- a/tests/test_prec.py
+++ b/tests/test_prec.py
@@ -16,7 +16,7 @@ from pp5.contacts import (
     Arpeggio,
 )
 from pp5.external_dbs import unp
-from pp5.external_dbs.pdb import PDB_DOWNLOAD_SOURCES
+from pp5.external_dbs.pdb import PDB_DOWNLOAD_SOURCES, split_id
 
 
 @pytest.fixture(
@@ -147,6 +147,19 @@ class TestMethods:
         for res_id, res_contacts in valid_contacts.items():
             assert res_id in prec
             assert res_contacts.contact_smax > 0
+
+    @pytest.mark.parametrize("pdb_id", ["1914:A", "2B3P:A", "4M2Q:A", "3P8D:A"])
+    def test_unmodelled_residues(self, pdb_id):
+        _, chain_id = split_id(pdb_id)
+        prec = ProteinRecord.from_pdb(pdb_id)
+
+        pdb_meta = prec.pdb_meta
+        canonical_seq = pdb_meta.entity_sequence[pdb_meta.chain_entities[chain_id]]
+
+        # The sequence in our prec structure should be identical to the canonical
+        # sequence in the PDB file, except where there are ligands.
+        aa_seq_no_ligands = prec.aa_seq.replace(UNKNOWN_AA, "")
+        assert aa_seq_no_ligands == canonical_seq
 
 
 class TestFromUnp:

--- a/tests/test_prec.py
+++ b/tests/test_prec.py
@@ -161,6 +161,14 @@ class TestMethods:
         aa_seq_no_ligands = prec.aa_seq.replace(UNKNOWN_AA, "")
         assert aa_seq_no_ligands == canonical_seq
 
+        # Make sure UNP alignment is correct and includes both modelled and
+        # unmodelled residues
+        unp_seq = prec.unp_rec.sequence
+        assert not all(r.unp_idx is None for r in prec)
+        assert all(
+            [unp_seq[r.unp_idx] == r.name for r in prec if r.unp_idx is not None]
+        )
+
 
 class TestFromUnp:
     def test_from_unp_default_selector(self):


### PR DESCRIPTION
- Un-modelled residues are now detected by using the PDB canonical sequence.
- Support detecting unmodelled residues on either side (N/C terminus).
- Keep non-standard residues that are modelled but don't appear in the canonical sequence.