### PR TITLE
Contacts missing residue bugfix

### DIFF
--- a/tests/test_prec.py
+++ b/tests/test_prec.py
@@ -60,7 +60,7 @@ def with_codons(request):
 
 
 class TestMethods:
-    @pytest.fixture(autouse=False, scope="class", params=["102L:A", "2WUR:A"])
+    @pytest.fixture(autouse=False, scope="class", params=["102L:A", "2WUR:A", "1914:A"])
     def pdb_id(self, request):
         return request.param
 


### PR DESCRIPTION
Fix an issue where the `prec` collection would sometimes fail to obtain contacts in the presence of un-modelled residues.